### PR TITLE
Added rtd theme to docs requirements

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,8 +1,7 @@
 -r prd.txt
 tox==4.15.0
 sphinx
-# sphinx-automodapi
 sphinx-autoapi
 sphinx-issues
 nbsphinx
-sphinx_book_theme
+sphinx-rtd-theme


### PR DESCRIPTION
This will hopefully address the latest docs issue. The theme was missing fromt the requirements file but has now been added.